### PR TITLE
ficks duplicatesStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 jar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+
     manifest {
         attributes "Main-Class": mainClassName
     }


### PR DESCRIPTION
Fixes an issue I had when trying to build
```
> Task :compileJava
Note: /home/cloudburst/yarn-remapper/src/main/java/me/seasnail/yarnremapper/GUI.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :jar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jar'.
> Entry META-INF/INDEX.LIST is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.1.1/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 22s
2 actionable tasks: 2 executed
```